### PR TITLE
Auto-detection of Azure cloud from azure.json

### DIFF
--- a/src/azip/azure.go
+++ b/src/azip/azure.go
@@ -42,11 +42,12 @@ func backoffExp(f func() error, errPre string) error {
 }
 
 func initClients(env map[string]string) (network.InterfacesClient, compute.VirtualMachinesClient) {
-	rmEndpoint := azure.PublicCloud.ResourceManagerEndpoint
-	// handle other endpoints like Azure Gov/China/etc
-	if uri := os.Getenv("RESOURCE_MANAGER_ENDPOINT"); uri != "" {
-		rmEndpoint = uri
+	azEnvironment, err := azure.EnvironmentFromName(env["AZURE_CLOUD_NAME"])
+	if err != nil {
+		fmt.Printf("ERROR: %s", err.Error())
+		os.Exit(1)
 	}
+	rmEndpoint := azEnvironment.ResourceManagerEndpoint
 
 	spt, err := helpers.NewServicePrincipalTokenFromCredentials(env, rmEndpoint)
 	if err != nil {

--- a/src/azip/main.go
+++ b/src/azip/main.go
@@ -29,6 +29,7 @@ type AzureConfig struct {
 	AzureTenantID       string `json:"tenantId"`
 	AzureSubscriptionID string `json:"subscriptionId"`
 	AzureClientSecret   string `json:"aadClientSecret"`
+	AzureCloudName      string `json:"cloud"`
 }
 
 func main() {
@@ -44,6 +45,7 @@ func main() {
 	}
 
 	env := map[string]string{
+		"AZURE_CLOUD_NAME":      config.AzureCloudName,
 		"AZURE_CLIENT_ID":       config.AzureClientID,
 		"AZURE_CLIENT_SECRET":   config.AzureClientSecret,
 		"AZURE_SUBSCRIPTION_ID": config.AzureSubscriptionID,


### PR DESCRIPTION
Not tested this yet, will update once I have if necessary. 

Fairly minor change but should enable the service to auto-detect the cloud and resource manager endpoint directly to support China / Gov etc... There may be other things that don't work there :p But this will at least auto-detect. Uses the `cloud` attribute from the `azure.json` that's mounted into the ip-allocator daemonset.